### PR TITLE
fix typo: GHEC -> GEHC. GE Healthcare.

### DIFF
--- a/nasdaq_100_ticker_history/n100-ticker-changes-2023.yaml
+++ b/nasdaq_100_ticker_history/n100-ticker-changes-2023.yaml
@@ -108,7 +108,7 @@ changes:
     difference:
       - FISV
     union:
-      - GHEC
+      - GEHC
 
   '2023-06-20':
     difference:

--- a/nasdaq_100_ticker_history/n100-ticker-changes-2024.yaml
+++ b/nasdaq_100_ticker_history/n100-ticker-changes-2024.yaml
@@ -43,7 +43,7 @@ tickers_on_Jan_1:
   - FAST
   - FTNT
   - GFS
-  - GHEC
+  - GEHC
   - GILD
   - GOOG
   - GOOGL

--- a/tests/test_n100_tickers.py
+++ b/tests/test_n100_tickers.py
@@ -88,7 +88,7 @@ def test_jun_jul_2023_changes() -> None:
     num_tickers_2023 = 101
     assert len(tickers_as_of(2023, 1, 1)) == num_tickers_2023
 
-    _test_one_swap(datetime.date.fromisoformat("2023-06-07"), "FISV", "GHEC", num_tickers_2023)
+    _test_one_swap(datetime.date.fromisoformat("2023-06-07"), "FISV", "GEHC", num_tickers_2023)
     _test_one_swap(datetime.date.fromisoformat("2023-06-20"), "RVIN", "ON", num_tickers_2023)
     _test_one_swap(datetime.date.fromisoformat("2023-07-17"), "ATVI", "TTD", num_tickers_2023)
 


### PR DESCRIPTION
This has been there since I originally mistakenly added  GE Healthcare as GHEC.  The correct ticker is: GEHC.