### PR TITLE
Fix typo: RVIN should be RIVN

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,15 @@ Release History
 
 .. towncrier release notes start
 
+Nasdaq_100_Ticker_History 2025.1.0 (2024-12-15)
+===============================================
+
+Bug Fix
+-------
+
+The ticker symbol for Rivian Automotive Inc was incorrectly listed as RVIN instead of the correct RIVN during the period in 2022 - 2023 when it was in the index.  Thanks to DRAirey1 for catching this.
+
+
 Nasdaq_100_Ticker_History 2025.0.0 (2024-12-14)
 ==============================================
 

--- a/nasdaq_100_ticker_history/n100-ticker-changes-2022.yaml
+++ b/nasdaq_100_ticker_history/n100-ticker-changes-2022.yaml
@@ -146,5 +146,5 @@ changes:
       - CSGP
       - FANG
       - GFS
-      - RVIN
+      - RIVN
       - WBD

--- a/nasdaq_100_ticker_history/n100-ticker-changes-2023.yaml
+++ b/nasdaq_100_ticker_history/n100-ticker-changes-2023.yaml
@@ -85,7 +85,7 @@ tickers_on_Jan_1:
   - QCOM
   - REGN
   - ROST
-  - RVIN
+  - RIVN
   - SBUX
   - SGEN
   - SIRI
@@ -112,7 +112,7 @@ changes:
 
   '2023-06-20':
     difference:
-      - RVIN
+      - RIVN
     union:
       - ON
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nasdaq-100-ticker-history"
-version = "2025.0.0"
+version = "2025.1.0"
 description = "Return NASDAQ 100 ticker symbols by date."
 authors = ["Jeff McCarrell <jeff@mccarrell.org>"]
 license = "MIT"

--- a/tests/test_n100_tickers.py
+++ b/tests/test_n100_tickers.py
@@ -121,7 +121,7 @@ def test_jun_jul_2023_changes() -> None:
     assert len(tickers_as_of(2023, 1, 1)) == num_tickers_2023
 
     _test_one_swap(datetime.date.fromisoformat("2023-06-07"), "FISV", "GEHC", num_tickers_2023)
-    _test_one_swap(datetime.date.fromisoformat("2023-06-20"), "RVIN", "ON", num_tickers_2023)
+    _test_one_swap(datetime.date.fromisoformat("2023-06-20"), "RIVN", "ON", num_tickers_2023)
     _test_one_swap(datetime.date.fromisoformat("2023-07-17"), "ATVI", "TTD", num_tickers_2023)
 
 
@@ -143,7 +143,7 @@ def test_2022_annual_changes() -> None:
     assert len(tickers_as_of(2022, 12, 15)) == num_tickers_2022_end_of_year + 1
     tickers_removed_2022_12_19 = frozenset(("BIDU", "DOCU", "MTCH", "NTES", "SPLK", "VRSN"))
     assert tickers_removed_2022_12_19.issubset(tickers_as_of(2022, 12, 15))
-    tickers_added_2022_12_19 = frozenset(("BKR", "CSGP", "FANG", "GFS", "RVIN", "WBD"))
+    tickers_added_2022_12_19 = frozenset(("BKR", "CSGP", "FANG", "GFS", "RIVN", "WBD"))
     assert tickers_added_2022_12_19.isdisjoint(tickers_as_of(2022, 12, 15))
 
     assert len(tickers_as_of(2022, 12, 19)) == num_tickers_2022_end_of_year


### PR DESCRIPTION
The ticker symbol for Rivian Automotive Inc was incorrectly listed as RVIN instead of the correct RIVN during the period in 2022 - 2023 when it was in the index.  Thanks to @
DRAirey1 for catching this.