### PR TITLE
fix: add Trip.com symbol rename in 2019

### DIFF
--- a/nasdaq_100_ticker_history/n100-ticker-changes-2016.yaml
+++ b/nasdaq_100_ticker_history/n100-ticker-changes-2016.yaml
@@ -27,6 +27,7 @@ tickers_on_Jan_1:
   - CMCSA
   - COST
   - CSCO
+  - CTRP
   - CTSH
   - CTXS
   - DISCA
@@ -90,7 +91,6 @@ tickers_on_Jan_1:
   - SRCL
   - STX
   - SWKS
-  - TCOM
   - TMUS
   - TRIP
   - TSCO

--- a/nasdaq_100_ticker_history/n100-ticker-changes-2017.yaml
+++ b/nasdaq_100_ticker_history/n100-ticker-changes-2017.yaml
@@ -28,6 +28,7 @@ tickers_on_Jan_1:
   - CSCO
   - CSX
   - CTAS
+  - CTRP
   - CTSH
   - CTXS
   - DISCA
@@ -89,7 +90,6 @@ tickers_on_Jan_1:
   - SIRI
   - STX
   - SWKS
-  - TCOM
   - TMUS
   - TRIP
   - TSCO

--- a/nasdaq_100_ticker_history/n100-ticker-changes-2018.yaml
+++ b/nasdaq_100_ticker_history/n100-ticker-changes-2018.yaml
@@ -30,6 +30,7 @@ tickers_on_Jan_1:
   - CSCO
   - CSX
   - CTAS
+  - CTRP
   - CTSH
   - CTXS
   - DISH
@@ -89,7 +90,6 @@ tickers_on_Jan_1:
   - SNPS
   - STX
   - SWKS
-  - TCOM
   - TMUS
   - TSLA
   - TTWO

--- a/nasdaq_100_ticker_history/n100-ticker-changes-2019.yaml
+++ b/nasdaq_100_ticker_history/n100-ticker-changes-2019.yaml
@@ -30,6 +30,7 @@ tickers_on_Jan_1:
   - CSCO
   - CSX
   - CTAS
+  - CTRP
   - CTSH
   - CTXS
   - DLTR
@@ -87,7 +88,6 @@ tickers_on_Jan_1:
   - SIRI
   - SNPS
   - SWKS
-  - TCOM
   - TMUS
   - TSLA
   - TTWO
@@ -106,6 +106,12 @@ tickers_on_Jan_1:
   - XLNX
 
 changes:
+  '2019-11-05':
+    difference:
+      - CTRP
+    union:
+      - TCOM
+
   '2019-11-19':
     difference:
       - CELG

--- a/tests/test_n100_2019.py
+++ b/tests/test_n100_2019.py
@@ -9,6 +9,14 @@ def test_tickers_2019() -> None:
 
     _test_at_year_boundary(2019)
 
+    # https://www.nasdaq.com/press-release/exelon-corporation-to-join-the-nasdaq-100-index-beginning-november-21-2019-2019-11-18
+    _test_one_swap(datetime.date.fromisoformat("2019-11-19"), "CELG", "EXC", num_tickers_2019)
+
+    # Ctrip.com International, Ltd. (CTRP) will change its name, trading symbol,
+    # and CUSIP to Trip.com Group Limited (TCOM), CUSIP 89677Q107
+    # https://www.miaxglobal.com/sites/default/files/alert-files/CTRP_Symbol_Name___45919.pdf
+    _test_one_swap(datetime.date.fromisoformat("2019-11-05"), "CTRP", "TCOM", num_tickers_2019)
+
     # 6 tickers added and removed on 12/23/2019
     # https://finance.yahoo.com/news/annual-changes-nasdaq-100-index-010510822.html
     tickers_2019_dec_23 = tickers_as_of(2019, 12, 23)
@@ -23,9 +31,6 @@ def test_tickers_2019() -> None:
     assert dec_23_removals.issubset(tickers_2019_dec_20)
     assert tickers_2019_dec_20.isdisjoint(dec_23_additions)
 
-    # 1 swap Nov 19
-    # https://www.nasdaq.com/press-release/exelon-corporation-to-join-the-nasdaq-100-index-beginning-november-21-2019-2019-11-18
-    _test_one_swap(datetime.date.fromisoformat("2019-11-19"), "CELG", "EXC", num_tickers_2019)
 
     # there was a record of 21st Century Fox changing to Fox Corp.  But as near as I can tell, the ticker
     # symbols were the same.


### PR DESCRIPTION
Trip.com has been reported as TCOM, which was correct as of 4 Nov 2019.
However, before that, the companies symbol was CTRP.  The data are now corrected.

[Cf](https://www.miaxglobal.com/sites/default/files/alert-files/CTRP_Symbol_Name___45919.pdf)
