### PR TITLE
Upgrade GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8.0.0
 
       - name: Set up Python
         run: uv python install 3.14

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ filename = "docs/changelog.rst"
 
 
 [build-system]
-requires = ["uv_build>=0.8.0"]
+requires = ["uv_build>=0.8.0,<0.12"]
 build-backend = "uv_build"
 
 


### PR DESCRIPTION
## Summary
- `actions/checkout` v5 → v6 (Node 24)
- `astral-sh/setup-uv` v5 → v8.0.0 (Node 24)
- Bound `uv_build` upper version `<0.12`
- `softprops/action-gh-release` stays at v2 (no Node 24 version yet)

Node 20 actions deprecated; forced to Node 24 starting June 2, 2026.

## Test plan
- [x] Validate workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)