### PR TITLE
retain historically exported symbols; no new changes syms

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,9 +42,9 @@ of additions and removals, anchored at a fixed ``BASELINE_DATE`` (January 1,
 2020) so coverage expansion in either direction does not shift any previously
 emitted event:
 
->>> from nasdaq_100_ticker_history import (
-...     BASELINE_DATE, BASELINE_MEMBERSHIP, changes_since, changes_before,
-... )
+>>> from nasdaq_100_ticker_history.changes import (
+       BASELINE_DATE, BASELINE_MEMBERSHIP, changes_since, changes_before,
+    )
 >>> first_post_baseline = next(iter(changes_since()))
 >>> first_post_baseline.effective_date.isoformat()
 '2020-04-20'

--- a/src/nasdaq_100_ticker_history/__init__.py
+++ b/src/nasdaq_100_ticker_history/__init__.py
@@ -1,17 +1,5 @@
-from .changes import (
-    BASELINE_DATE,
-    BASELINE_MEMBERSHIP,
-    MembershipChange,
-    changes_before,
-    changes_since,
-)
 from .n100tickers import tickers_as_of
 
 __all__ = [
-    "BASELINE_DATE",
-    "BASELINE_MEMBERSHIP",
-    "MembershipChange",
-    "changes_before",
-    "changes_since",
     "tickers_as_of",
 ]

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -4,15 +4,15 @@ import datetime
 
 import pytest
 
-from nasdaq_100_ticker_history import (
+from nasdaq_100_ticker_history import tickers_as_of
+from nasdaq_100_ticker_history.changes import (
     BASELINE_DATE,
     BASELINE_MEMBERSHIP,
     MembershipChange,
+    _covered_years,
     changes_before,
     changes_since,
-    tickers_as_of,
 )
-from nasdaq_100_ticker_history.changes import _covered_years
 
 
 def test_baseline_date_is_2020_01_01() -> None:


### PR DESCRIPTION
This package has for many years only exported tickers_as_of
into the namespace of consumers.  Retain that.
Consumers of the changes API will need to import it from the
changes module.
