### PR TITLE
tooling: skip magic trailing commas in ruff format

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,10 +38,7 @@ release = version
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    "sphinx.ext.autodoc",
-    "sphinx.ext.doctest",
-]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.doctest"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -32,7 +32,13 @@ line-length = 108
 [format]
 # enable reformatting of code snippets in docstrings.
 docstring-code-format = true
+# don't force per-line splits on trailing commas when the unsplit form fits.
+skip-magic-trailing-comma = true
 
 
 [lint]
 select = ["I"]  # Enables isort import sorting
+
+[lint.isort]
+# Pair with format.skip-magic-trailing-comma=true above so isort doesn't undo what the formatter respects.
+split-on-trailing-comma = false

--- a/src/nasdaq_100_ticker_history/__init__.py
+++ b/src/nasdaq_100_ticker_history/__init__.py
@@ -1,5 +1,3 @@
 from .n100tickers import tickers_as_of
 
-__all__ = [
-    "tickers_as_of",
-]
+__all__ = ["tickers_as_of"]

--- a/src/nasdaq_100_ticker_history/changes.py
+++ b/src/nasdaq_100_ticker_history/changes.py
@@ -237,8 +237,4 @@ def changes_before() -> Iterator[MembershipChange]:
                 pre.append((d, additions, removals))
     pre.sort(key=lambda x: x[0], reverse=True)
     for d, forward_additions, forward_removals in pre:
-        yield MembershipChange(
-            effective_date=d,
-            additions=forward_removals,
-            removals=forward_additions,
-        )
+        yield MembershipChange(effective_date=d, additions=forward_removals, removals=forward_additions)

--- a/src/nasdaq_100_ticker_history/n100tickers.py
+++ b/src/nasdaq_100_ticker_history/n100tickers.py
@@ -15,13 +15,7 @@ date_schema = MapPattern(
     changes_schema,
 )
 
-ticker_schema = Map(
-    {
-        "year": Int(),
-        "tickers_on_Jan_1": UniqueSeq(Str()),
-        Optional("changes"): date_schema,
-    }
-)
+ticker_schema = Map({"year": Int(), "tickers_on_Jan_1": UniqueSeq(Str()), Optional("changes"): date_schema})
 
 
 @lru_cache

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -87,9 +87,7 @@ def test_changes_before_reproduces_tickers_as_of_predecessor() -> None:
 
 def test_membership_change_is_frozen() -> None:
     chg = MembershipChange(
-        effective_date=datetime.date(2020, 1, 1),
-        additions=frozenset({"AAA"}),
-        removals=frozenset({"BBB"}),
+        effective_date=datetime.date(2020, 1, 1), additions=frozenset({"AAA"}), removals=frozenset({"BBB"})
     )
     with pytest.raises(Exception):
         chg.effective_date = datetime.date(2021, 1, 1)  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- Add \`format.skip-magic-trailing-comma = true\` and \`lint.isort.split-on-trailing-comma = false\` to ruff.toml so the formatter respects existing layout choices and only splits when the unsplit form would exceed \`line-length = 108\`.
- Apply the resulting formatter sweep to \`docs/conf.py\`, \`__init__.py\`, \`changes.py\`, \`n100tickers.py\`, and \`test_changes.py\` (compaction of previously-split function signatures and collection literals).

## Test plan
- [x] \`just lint\` exits 0 on a clean tree
- [x] \`just lint\` modifies no files (idempotent)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)