### PR TITLE
Apply June 2026 quarterly NDX reconstitution

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,13 @@ Release History
 
 .. towncrier release notes start
 
+Nasdaq_100_Ticker_History 2026.7.0 (2026-06-24)
+===============================================
+
+User-Visible Changes
+--------------------
+- Applied the June 2026 quarterly Nasdaq-100 reconstitution effective June 22, 2026: added Astera Labs (ALAB), CoreWeave (CRWV), Nebius Group (NBIS), Rocket Lab (RKLB), and Teradyne (TER); removed Charter Communications (CHTR), Cognizant (CTSH), Insmed (INSM), Verisk Analytics (VRSK), and Zscaler (ZS).  Source: https://ir.nasdaq.com/news-releases/news-release-details/nasdaq-100-indexr-june-2026-quarterly-changes
+
 Nasdaq_100_Ticker_History 2026.6.0 (2026-05-27)
 ===============================================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ set of ticker symbols (eg, ``AAPL``) that were in the index on that date.
 Coverage
 --------
 
-As of version |release|, accurate coverage is provided from Jan 1, 2015 through at least April 29, 2026.  Most
+As of version |release|, accurate coverage is provided from Jan 1, 2015 through at least June 22, 2026.  Most
 likely, the coverage is accurate further into 2026 subject to additional changes being announced by Nasdaq.  A new
 version of the API is released on each update Nasdaq announces, typically with a time lag of a few days to a
 few weeks.  It is the intent of the project maintainers to provide accurate coverage on an ongoing basis.

--- a/src/nasdaq_100_ticker_history/n100-ticker-changes-2026.yaml
+++ b/src/nasdaq_100_ticker_history/n100-ticker-changes-2026.yaml
@@ -125,3 +125,16 @@ changes:
       - CSGP
     union:
       - LITE
+  "2026-06-22":
+    difference:
+      - CHTR
+      - CTSH
+      - INSM
+      - VRSK
+      - ZS
+    union:
+      - ALAB
+      - CRWV
+      - NBIS
+      - RKLB
+      - TER

--- a/tests/test_n100_2026.py
+++ b/tests/test_n100_2026.py
@@ -41,3 +41,28 @@ def test_apr_2026_sndk_team_swap() -> None:
 def test_may_2026_lite_csgp_swap() -> None:
     # On May 18, Lumentum (LITE) replaced CoStar Group (CSGP)
     _test_one_swap(datetime.date.fromisoformat("2026-05-18"), "CSGP", "LITE", num_tickers_2026)
+
+
+def test_jun_2026_quarterly_reconstitution() -> None:
+    # On Jun 22, 2026, quarterly reconstitution:
+    # Removed: CHTR, CTSH, INSM, VRSK, ZS
+    # Added: ALAB, CRWV, NBIS, RKLB, TER
+    # Source: https://ir.nasdaq.com/news-releases/news-release-details/nasdaq-100-indexr-june-2026-quarterly-changes
+    tickers_before = tickers_as_of(2026, 6, 21)
+    tickers_after = tickers_as_of(2026, 6, 22)
+
+    # Total should remain 101 (5 removed, 5 added)
+    assert len(tickers_before) == num_tickers_2026
+    assert len(tickers_after) == num_tickers_2026
+
+    # Verify removals
+    removed = {"CHTR", "CTSH", "INSM", "VRSK", "ZS"}
+    for ticker in removed:
+        assert ticker in tickers_before
+        assert ticker not in tickers_after
+
+    # Verify additions
+    added = {"ALAB", "CRWV", "NBIS", "RKLB", "TER"}
+    for ticker in added:
+        assert ticker not in tickers_before
+        assert ticker in tickers_after


### PR DESCRIPTION
Implements the June 2026 quarterly Nasdaq-100 reconstitution announced by Nasdaq, effective Monday June 22, 2026.

## Changes
- **Added:** Astera Labs (ALAB), CoreWeave (CRWV), Nebius Group (NBIS), Rocket Lab (RKLB), Teradyne (TER)
- **Removed:** Charter Communications (CHTR), Cognizant (CTSH), Insmed (INSM), Verisk Analytics (VRSK), Zscaler (ZS)

Net membership unchanged at 101.

## What's in here
- New `2026-06-22` change entry in `n100-ticker-changes-2026.yaml`
- `test_jun_2026_quarterly_reconstitution` verifying the 5-in/5-out swap on the boundary
- Coverage statement in `docs/index.rst` bumped to "through at least June 22, 2026"
- `2026.7.0` changelog section

`just check-all` passes (50 tests, 99% coverage, typing clean).

Source: https://ir.nasdaq.com/news-releases/news-release-details/nasdaq-100-indexr-june-2026-quarterly-changes

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)