### PR TITLE
Backfill changelog entries for 2026.4.0–2026.6.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,35 @@ Release History
 
 .. towncrier release notes start
 
+Nasdaq_100_Ticker_History 2026.6.0 (2026-05-27)
+===============================================
+
+User-Visible Changes
+--------------------
+- Added Lumentum (LITE) to the index, replacing CoStar Group (CSGP) effective May 18, 2026.
+
+Internal Changes
+----------------
+- ``just lint`` no longer runs ``ruff format`` destructively, and ruff is configured to skip magic trailing commas when formatting.
+
+Nasdaq_100_Ticker_History 2026.5.0 (2026-05-04)
+===============================================
+
+User-Visible Changes
+--------------------
+- Restored the long-standing public surface so that only ``tickers_as_of`` is exported at the package top level. The membership-changes API is now imported from ``nasdaq_100_ticker_history.changes``.
+
+Nasdaq_100_Ticker_History 2026.4.0 (2026-05-03)
+===============================================
+
+User-Visible Changes
+--------------------
+- Added a bidirectional membership-changes API that exposes the index history as forward and backward streams (see ``docs/api/changes.rst``).
+
+Internal Changes
+----------------
+- Scaffolded agent skills and wired the shared worktree workflow into the justfile.
+
 Nasdaq_100_Ticker_History 2026.3.0 (2026-04-29)
 ===============================================
 


### PR DESCRIPTION
The changelog had lagged at `2026.3.0` even though `2026.4.0`, `2026.5.0`, and `2026.6.0` were all released. The towncrier fragments dir is empty (`.gitkeep` only) and `docs/changelog.rst` is hand-maintained, so those releases never got entries. This reconstructs them from each tag's git history.

## Entries added (descending, above 2026.3.0)
- **2026.6.0** (2026-05-27) — LITE→CSGP swap (#72); ruff-format tooling fixes (#70)
- **2026.5.0** (2026-05-04) — restored top-level export of only `tickers_as_of` (#69)
- **2026.4.0** (2026-05-03) — bidirectional membership-changes API (#68); agent-skill + worktree scaffolding

Docs-only; `just check-all` passes.

> **Merge-order note:** [#74](https://github.com/jmccarrell/n100tickers/pull/74) also inserts a `2026.7.0` entry at the same anchor (right after the towncrier marker). Whichever PR merges second will hit a trivial `docs/changelog.rst` conflict — resolution is to keep both blocks with `2026.7.0` on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)