### PR TITLE
ci: bump action-gh-release to v3 (Node 24 runtime)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         run: uv build
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           generate_release_notes: true


### PR DESCRIPTION
GitHub Actions runners now flag the release workflow:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: softprops/action-gh-release@v2.

`softprops/action-gh-release` v3.0.0 moves the action runtime from Node 20 to Node 24, and the maintainer keeps a floating `v3` major tag. This bumps the pin in `.github/workflows/release.yml` from `@v2` to `@v3`, matching the repo's existing major-tag convention.

Verified `v3.0.1` ships `using: "node24"` in its `action.yml`.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

🤖 Generated with [Claude Code](https://claude.com/claude-code)